### PR TITLE
Adds `refresh` method to re-fetch `[data-modal]`

### DIFF
--- a/index.js
+++ b/index.js
@@ -704,7 +704,17 @@
 		}
 	};
 
+	
+	/**
+	 * If modals are being added to the DOM dynamically, redefine the modal variable
+	 * and initialize again.
+	 */
+	ARIAmodal.refresh = function () {
+		modal = doc.querySelectorAll('[data-modal]');
+		ARIAmodal.init();
+	};
 
+	
 	/**
 	 * Initialize modal functions.
 	 * If expanding this script, put

--- a/index.js
+++ b/index.js
@@ -711,6 +711,7 @@
 	 */
 	ARIAmodal.refresh = function () {
 		modal = doc.querySelectorAll('[data-modal]');
+		children = doc.querySelectorAll('body > *:not([data-modal])');
 		ARIAmodal.init();
 	};
 


### PR DESCRIPTION
See #6 for more information.

I know this isn't the best solution, but I'm not a great JS developer.

Another alternative would be to add something like this:

```
/**
 * @param {Element} item
 */
ARIAmodal.addModal = function ( item ) {
	modal.push( item );	
};
```

and then refactor `setupModal` so it runs only on one modal at a time, then add a new `setupModals` method that would loop through all the items in the `modal` array and run `setupModal` on them.

Again, I'm not great at JS. Thank you for the script, and please let me know if I can help with the PR.

Closes #6 