### PR TITLE
Improve compatibility with wicg-inert

### DIFF
--- a/index.js
+++ b/index.js
@@ -526,21 +526,24 @@
 		 * Return focus to the trigger that opened the modal dialog.
 		 * If the trigger doesn't exist for some reason, move focus to
 		 * either the <main>, or <body> instead.
+		 * Note: Wait a tick before setting focus. See https://github.com/WICG/inert#performance-and-gotchas
 		 * Reset initialTrigger and activeModal since everything should be reset.
 		 */
-		if ( trigger !== null ) {
-			trigger.focus();
-		}
-		else {
-			if ( main && !returnToBody ) {
-				main.tabIndex = -1;
-				main.focus();
+		Promise.resolve().then(function() {
+			if ( trigger !== null ) {
+				trigger.focus();
 			}
 			else {
-				body.tabIndex = -1;
-				body.focus();
+				if ( main && !returnToBody ) {
+					main.tabIndex = -1;
+					main.focus();
+				}
+				else {
+					body.tabIndex = -1;
+					body.focus();
+				}
 			}
-		}
+		});
 
 		initialTrigger = undefined;
 		activeModal = undefined;

--- a/index.js
+++ b/index.js
@@ -529,7 +529,7 @@
 		 * Note: Wait a tick before setting focus. See https://github.com/WICG/inert#performance-and-gotchas
 		 * Reset initialTrigger and activeModal since everything should be reset.
 		 */
-		Promise.resolve().then(function() {
+		setTimeout(function() {
 			if ( trigger !== null ) {
 				trigger.focus();
 			}
@@ -543,7 +543,7 @@
 					body.focus();
 				}
 			}
-		});
+		}, 0);
 
 		initialTrigger = undefined;
 		activeModal = undefined;


### PR DESCRIPTION
When trying to use https://github.com/WICG/inert as the inert polyfill, I found that setting focus after closing the modal was not working because inert was not really removed yet when focus was being set. Here's a quote from the wing-inert README about the issue:

> It relies on mutation observers to detect the addition of the `inert`
  attribute, and to detect dynamically added content within inert subtrees.
  Testing for _inert_-ness in any way immediately after either type of mutation
  will therefore give inconsistent results; please allow the current task to end
  before relying on mutation-related changes to take effect, for example via
  `setTimeout(fn, 0)` or `Promise.resolve()`.