### PR TITLE
Added support for multiple triggers

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,7 +135,7 @@
 				 * Get modal target and supply the button with a unique ID to easily
 				 * reference for returning focus to, once the modal dialog is closed.
 				 */
-				self.id = getOpenTarget + '__trigger-' + self.nodeName;
+				self.id = getOpenTarget + '__trigger-' + self.nodeName + '-' + i;
 
 				/**
 				 * Events


### PR DESCRIPTION
Multiple triggers were triggering before, but were not being focused after the dialog is closed. Instead, the first trigger was focused. Furthermore, the id's generated by the script were not unique when there were two identical buttons on the page (for example header and footer buttons)

This change makes the id's more unique and allows opening the modal from multiple pages.